### PR TITLE
Constructor added to MvxCircleImageView to avoid inflating issues

### DIFF
--- a/CircleImageView/MvxCircleImageView.cs
+++ b/CircleImageView/MvxCircleImageView.cs
@@ -77,6 +77,10 @@ namespace Rocket.Droid
 			Init();			
 		}
 
+		public MvxCircleImageView(IntPtr javaRef, Android.Runtime.JniHandleOwnership transfer) : base(javaRef, transfer)
+		{
+		}
+
 		private void Init() {
 			this.SetScaleType (SCALE_TYPE);
 			mReady = true;


### PR DESCRIPTION
MvxCircleImageView throws an inflating error at runtime. Just adding the default java constructor did it.
Even with no code in the constructor it works
